### PR TITLE
2015 principles are largely deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Zalando's Engineering and Architecture Principles
 
+**This repository is deprecated. The below principles were introduced in 2015 and no longer reflect the current reality (2020) in all aspects.
+To learn more about our current practices, please follow our Engineering Blog on https://engineering.zalando.com/ **
+
 #### The Principles, Briefly
 
 As part of [Radical Agility](https://jobs.zalando.com/tech/blog/so-youve-heard-about-radical-agility...-video/), implemented by Zalando's technology team in March 2015, we have adopted this set of principles for tech and architecture:


### PR DESCRIPTION
The repository was not updated for a long time. The last content update was done in 2018 when Zalando's Principal Engineering Community was not yet formed. Add a note that the repository is deprecated and no longer reflects the current reality.

We might want to revise and set up new Zalando Engineering Principles, but this will take more time :smile: 